### PR TITLE
podcast selection selection loads correct list

### DIFF
--- a/src/components/screens/Podcasts/index.jsx
+++ b/src/components/screens/Podcasts/index.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { ScrollView, View } from 'react-native'
 import styled from 'styled-components'
 
+import { selectPodcast } from '@app/modules/podcasts/actions'
 import PodcastItem from './PodcastItem'
 
 const Podcasts = (props) => (
@@ -11,7 +12,10 @@ const Podcasts = (props) => (
 			{props.subscriptions.map((podcast) => (
 				<PodcastItem
 					key={podcast.url}
-					onPress={() => props.navigation.push('Episodes')}
+					onPress={() => {
+						props.selectPodcast(podcast.title)
+						props.navigation.navigate('Episodes')
+					}}
 					image={podcast.image}
 				/>
 			))}
@@ -26,5 +30,5 @@ const Wrapper = styled(View)`
 
 export default connect(
 	(state) => ({ subscriptions: state.podcasts.subscriptions }),
-	{}
+	{ selectPodcast }
 )(Podcasts)

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -3,3 +3,8 @@ export const PLAY_STATE = {
 	PAUSED: 'paused',
 	STOPPED: 'stopped',
 }
+
+export const PODCAST_TITLE = {
+	JOE_ROGAN: 'The Joe Rogan Experience',
+	FREAKONOMICS: 'Freakonomics Radio',
+}

--- a/src/modules/podcasts/actions.js
+++ b/src/modules/podcasts/actions.js
@@ -1,0 +1,17 @@
+import { PODCAST_TITLE } from '@app/modules/constants'
+import freakonomics from './data/freakonomics'
+import joeRogan from './data/joe-rogan'
+
+export const selectPodcast = (podcast) => async (dispatch) => {
+	if (podcast === PODCAST_TITLE.JOE_ROGAN) {
+		dispatch({
+			type: 'SELECT_PODCAST',
+			payload: joeRogan,
+		})
+	} else if (podcast === PODCAST_TITLE.FREAKONOMICS) {
+		dispatch({
+			type: 'SELECT_PODCAST',
+			payload: freakonomics,
+		})
+	}
+}

--- a/src/modules/podcasts/reducer.js
+++ b/src/modules/podcasts/reducer.js
@@ -1,13 +1,19 @@
 import subscriptions from './data/subscriptions'
-import freakonomics from './data/freakonomics'
+import joeRogan from './data/joe-rogan'
 
 export const initialState = {
 	subscriptions,
-	currentPodcast: freakonomics,
+	currentPodcast: joeRogan,
 }
 
 export default function reducer(state = initialState, action) {
 	switch (action.type) {
+		case 'SELECT_PODCAST': {
+			return {
+				...state,
+				currentPodcast: action.payload,
+			}
+		}
 		case 'NOTHING_YET': {
 			return {
 				...state,


### PR DESCRIPTION
relates #9

I expect this isn't quite ready or correct. For now it allows you to select the podcast that is in your available subscriptions so that it goes to the correct one, an improvement on current situation.
But I think we need to review how the data will be coming down from iTunes and what we will be storing locally and how we will name and access this before we can do this properly.