### PR TITLE
Storybook: adding Player and Podcasts

### DIFF
--- a/src/components/screens/Player/EpisodeCover.js
+++ b/src/components/screens/Player/EpisodeCover.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Image, View } from 'react-native'
 import styled from 'styled-components'
-import { connect } from 'react-redux'
 
 const EpisodesImages = (props) => {
 	return (
@@ -24,9 +23,4 @@ const ImageComponent = styled(Image)`
 	border-radius: ${({ theme }) => theme.metrics.smallSize}px;
 `
 
-export default connect(
-	(state) => ({
-		currentTrack: state.player.currentTrack || {},
-	}),
-	{}
-)(EpisodesImages)
+export default EpisodesImages

--- a/src/components/screens/Player/PlayerControls.js
+++ b/src/components/screens/Player/PlayerControls.js
@@ -2,10 +2,6 @@ import React from 'react'
 import { View } from 'react-native'
 import styled from 'styled-components'
 import Button from '@app/components/common/Button'
-import { connect } from 'react-redux'
-
-import { playOrPause, skipSeconds } from '@app/modules/player/actions'
-import { PLAY_STATE } from '@app/modules/constants'
 
 const PlayerControls = (props) => {
 	return (
@@ -39,12 +35,4 @@ const ButtonsWrapper = styled(View)`
 	padding-right: ${({ theme }) => theme.metrics.extraLargeSize}px;
 `
 
-export default connect(
-	(state) => ({
-		isPlaying: state.player.playState === PLAY_STATE.PLAYING,
-	}),
-	{
-		playOrPause,
-		skipSeconds,
-	}
-)(PlayerControls)
+export default PlayerControls

--- a/src/components/screens/Player/PlayerScreen.jsx
+++ b/src/components/screens/Player/PlayerScreen.jsx
@@ -10,7 +10,7 @@ const PlayerScreen = (props) => (
 		<EpisodeCover currentTrack={props.currentTrack} />
 		<TrackTextInfo
 			currentTrack={props.currentTrack}
-			podcast={props.currentPodcast}
+			podcast={props.podcast}
 		/>
 		<ProgressBar
 			playbackInstancePosition={props.playbackInstancePosition}

--- a/src/components/screens/Player/PlayerScreen.jsx
+++ b/src/components/screens/Player/PlayerScreen.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import Screen from '@app/components/layout/Screen'
+import EpisodeCover from './EpisodeCover'
+import TrackTextInfo from './TrackTextInfo'
+import PlayerControls from './PlayerControls'
+import ProgressBar from './ProgressBar'
+
+const PlayerScreen = (props) => (
+	<Screen>
+		<EpisodeCover currentTrack={props.currentTrack} />
+		<TrackTextInfo
+			currentTrack={props.currentTrack}
+			podcast={props.currentPodcast}
+		/>
+		<ProgressBar
+			playbackInstancePosition={props.playbackInstancePosition}
+			playbackInstanceDuration={props.playbackInstanceDuration}
+			seekSliderValueChange={props.seekSliderValueChange}
+			seekSliderSlidingComplete={props.seekSliderSlidingComplete}
+		/>
+		<PlayerControls
+			isPlaying={props.isPlaying}
+			playOrPause={props.playOrPause}
+			skipSeconds={props.skipSeconds}
+		/>
+	</Screen>
+)
+
+export default PlayerScreen

--- a/src/components/screens/Player/ProgressBar.js
+++ b/src/components/screens/Player/ProgressBar.js
@@ -1,11 +1,6 @@
 import React from 'react'
 import { Text, View, Slider } from 'react-native'
 import styled from 'styled-components'
-import { connect } from 'react-redux'
-import {
-	seekSliderValueChange,
-	seekSliderSlidingComplete,
-} from '@app/modules/player/actions'
 
 const ProgressSlider = (props) => {
 	const getSeekSliderPosition = () => {
@@ -64,13 +59,4 @@ const SliderBar = styled(Slider)`
 	margin-top: ${({ theme }) => theme.metrics.smallSize}px;
 `
 
-export default connect(
-	(state) => ({
-		playbackInstancePosition: state.player.playbackInstancePosition,
-		playbackInstanceDuration: state.player.playbackInstanceDuration,
-	}),
-	{
-		seekSliderValueChange,
-		seekSliderSlidingComplete,
-	}
-)(ProgressSlider)
+export default ProgressSlider

--- a/src/components/screens/Player/TrackTextInfo.js
+++ b/src/components/screens/Player/TrackTextInfo.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { View, Text } from 'react-native'
 import styled from 'styled-components'
-import { connect } from 'react-redux'
 
 const TrackTextInfo = (props) => {
 	return (
@@ -30,10 +29,4 @@ const AuthorText = styled(EpisodeTitleText)`
 	margin: ${({ theme }) => theme.metrics.extraSmallSize}px;
 `
 
-export default connect(
-	(state) => ({
-		currentTrack: state.player.currentTrack || {},
-		podcast: state.podcasts.currentPodcast,
-	}),
-	{}
-)(TrackTextInfo)
+export default TrackTextInfo

--- a/src/components/screens/Player/index.jsx
+++ b/src/components/screens/Player/index.jsx
@@ -10,19 +10,19 @@ import {
 import { PLAY_STATE } from '@app/modules/constants'
 import PlayerScreen from './PlayerScreen'
 
-const Player = (props) => {
-	;<PlayerScreen
+const Player = (props) => (
+	<PlayerScreen
 		playbackInstancePosition={props.playbackInstancePosition}
 		playbackInstanceDuration={props.playbackInstanceDuration}
 		seekSliderValueChange={props.seekSliderValueChange}
 		seekSliderSlidingComplete={props.seekSliderSlidingComplete}
 		currentTrack={props.currentTrack}
-		podcast={props.currentPodcast}
+		podcast={props.podcast}
 		isPlaying={props.isPlaying}
 		playOrPause={props.playOrPause}
 		skipSeconds={props.skipSeconds}
 	/>
-}
+)
 
 export default connect(
 	(state) => ({

--- a/src/components/screens/Player/index.jsx
+++ b/src/components/screens/Player/index.jsx
@@ -1,17 +1,41 @@
 import React from 'react'
-import Screen from '@app/components/layout/Screen'
-import EpisodeCover from './EpisodeCover'
-import TrackTextInfo from './TrackTextInfo'
-import PlayerControls from './PlayerControls'
-import ProgressBar from './ProgressBar'
+import { connect } from 'react-redux'
+import {
+	seekSliderValueChange,
+	seekSliderSlidingComplete,
+	playOrPause,
+	skipSeconds,
+} from '@app/modules/player/actions'
 
-const Player = () => (
-	<Screen>
-		<EpisodeCover />
-		<TrackTextInfo />
-		<ProgressBar />
-		<PlayerControls />
-	</Screen>
-)
+import { PLAY_STATE } from '@app/modules/constants'
+import PlayerScreen from './PlayerScreen'
 
-export default Player
+const Player = (props) => {
+	;<PlayerScreen
+		playbackInstancePosition={props.playbackInstancePosition}
+		playbackInstanceDuration={props.playbackInstanceDuration}
+		seekSliderValueChange={props.seekSliderValueChange}
+		seekSliderSlidingComplete={props.seekSliderSlidingComplete}
+		currentTrack={props.currentTrack}
+		podcast={props.currentPodcast}
+		isPlaying={props.isPlaying}
+		playOrPause={props.playOrPause}
+		skipSeconds={props.skipSeconds}
+	/>
+}
+
+export default connect(
+	(state) => ({
+		playbackInstancePosition: state.player.playbackInstancePosition,
+		playbackInstanceDuration: state.player.playbackInstanceDuration,
+		currentTrack: state.player.currentTrack || {},
+		podcast: state.podcasts.currentPodcast,
+		isPlaying: state.player.playState === PLAY_STATE.PLAYING,
+	}),
+	{
+		seekSliderValueChange,
+		seekSliderSlidingComplete,
+		playOrPause,
+		skipSeconds,
+	}
+)(Player)

--- a/src/components/screens/Podcasts/PodcastsScreen.jsx
+++ b/src/components/screens/Podcasts/PodcastsScreen.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { View, FlatList } from 'react-native'
+import styled from 'styled-components'
+
+import PodcastItem from './PodcastItem'
+
+const Podcasts = (props) => (
+	<Wrapper>
+		<FlatList
+			data={props.subscriptions}
+			numColumns={4}
+			renderItem={({ item }) => (
+				<Item
+					key={item.meta.description}
+					onPress={() => {
+						props.selectPodcast(item.meta.title)
+						props.navigation.navigate('Episodes')
+					}}
+					image={item.meta.imageURL}
+				/>
+			)}
+			keyExtractor={(item) => item.meta.imageURL}
+		/>
+	</Wrapper>
+)
+
+const Wrapper = styled(View)`
+	flex-direction: column;
+	align-items: center;
+`
+
+const Item = styled(PodcastItem)`
+	flex-direction: row;
+	flex-wrap: wrap;
+`
+
+export default Podcasts

--- a/src/components/screens/Podcasts/index.jsx
+++ b/src/components/screens/Podcasts/index.jsx
@@ -1,42 +1,17 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { View, FlatList } from 'react-native'
-import styled from 'styled-components'
-
 import { selectPodcast } from '@app/modules/podcasts/actions'
-import PodcastItem from './PodcastItem'
+import Podcasts from './PodcastsScreen'
 
-const Podcasts = (props) => (
-	<Wrapper>
-		<FlatList
-			data={props.subscriptions}
-			numColumns={4}
-			renderItem={({ item }) => (
-				<Item
-					key={item.meta.description}
-					onPress={() => {
-						props.selectPodcast(item.meta.title)
-						props.navigation.navigate('Episodes')
-					}}
-					image={item.meta.imageURL}
-				/>
-			)}
-			keyExtractor={(item) => item.meta.imageURL}
-		/>
-	</Wrapper>
+
+const PodcastsContainer = (props) => (
+	<Podcasts
+		subscriptions={props.subscriptionsList}
+		selectPodcast={props.selectPodcast}
+	/>
 )
 
-const Wrapper = styled(View)`
-	flex-direction: column;
-	align-items: center;
-`
-
-const Item = styled(PodcastItem)`
-	flex-direction: row;
-	flex-wrap: wrap;
-`
-
 export default connect(
-	(state) => ({ subscriptions: state.podcasts.subscriptions }),
+	(state) => ({ subscriptionsList: state.podcasts.subscriptions }),
 	{ selectPodcast }
-)(Podcasts)
+)(PodcastsContainer)

--- a/src/components/screens/Podcasts/index.jsx
+++ b/src/components/screens/Podcasts/index.jsx
@@ -7,6 +7,7 @@ const PodcastsContainer = (props) => (
 	<Podcasts
 		subscriptions={props.subscriptionsList}
 		selectPodcast={props.selectPodcast}
+		navigation={props.navigation}
 	/>
 )
 

--- a/src/components/screens/Podcasts/index.jsx
+++ b/src/components/screens/Podcasts/index.jsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux'
 import { selectPodcast } from '@app/modules/podcasts/actions'
 import Podcasts from './PodcastsScreen'
 
-
 const PodcastsContainer = (props) => (
 	<Podcasts
 		subscriptions={props.subscriptionsList}

--- a/storybook/stories/EpisodeList.js
+++ b/storybook/stories/EpisodeList.js
@@ -10,9 +10,13 @@ export default function () {
 			},
 			episodes: [
 				{
-					description: 'description',
-					title: 'title',
-					pubDate: '2020-04-27 00:00:00',
+					title:
+						'418. What Will College Look Like in the Fall (and Beyond)?',
+					description:
+						'Three university presidents try to answer our listeners’ questions. The result? Not much pomp and a whole lot of circumstance.',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-05-14T03:00:00.000Z',
 					enclosure: {
 						type: 'audio/mpeg',
 						duration: 3230,

--- a/storybook/stories/Player.js
+++ b/storybook/stories/Player.js
@@ -1,0 +1,714 @@
+import React from 'react'
+import PlayerScreen from '../../src/components/screens/Player/PlayerScreen'
+
+export default function () {
+	const props = {
+		playbackInstancePosition: 100000,
+		playbackInstanceDuration: 500000,
+		currentTrack: {
+			title: '418. What Will College Look Like in the Fall (and Beyond)?',
+			description:
+				'Three university presidents try to answer our listeners’ questions. The result? Not much pomp and a whole lot of circumstance.',
+			imageURL:
+				'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+			pubDate: '2020-05-14T03:00:00.000Z',
+			link:
+				'https://omny.fm/shows/freakonomics-radio/what-will-college-look-like-in-the-fall-and-beyond',
+			enclosure: {
+				length: '53607601',
+				type: 'audio/mpeg',
+				url:
+					'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/e4acbb27-0ffb-4579-bd34-abbb001adcc4/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+			},
+			duration: 3349,
+			summary:
+				'Three university presidents try to answer our listeners’ questions. The result? Not much pomp and a whole lot of circumstance.',
+		},
+		podcast: {
+			meta: {
+				title: 'Freakonomics Radio',
+				description:
+					'<p>Discover the hidden side of everything with Stephen J. Dubner, co-author of the&nbsp;<em>Freakonomics</em>&nbsp;books. Each week,&nbsp;<em>Freakonomics Radio</em>&nbsp;tells you things you always thought you knew (but didn’t) and things you never thought you wanted to know (but do) —&nbsp;from the economics of sleep to how to become great at just about anything. Dubner speaks with Nobel laureates and provocateurs, intellectuals and entrepreneurs, and various other underachievers. Special features include series like “The Secret Life of a C.E.O.” as well as a live game show, “Tell Me Something I Don’t Know.”&nbsp;</p>',
+				imageURL:
+					'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+				link: 'http://freakonomics.com/',
+				language: 'en-US',
+				author: 'Freakonomics Radio',
+				summary:
+					'Discover the hidden side of everything with Stephen J. Dubner, co-author of the Freakonomics books. Each week, Freakonomics Radio tells you things you always thought you knew (but didn’t) and things you never thought you wanted to know (but do) — from the economics of sleep to how to become great at just about anything. Dubner speaks with Nobel laureates and provocateurs, intellectuals and entrepreneurs, and various other underachievers. Special features include series like “The Secret Life of a C.E.O.” as well as a live game show, “Tell Me Something I Don’t Know.” ',
+				categories: ['Society & Culture', 'Documentary'],
+				owner: {
+					name: 'Stitcher',
+					email: 'originals@stitcher.com',
+				},
+				explicit: false,
+			},
+			episodes: [
+				{
+					title:
+						'418. What Will College Look Like in the Fall (and Beyond)?',
+					description:
+						'Three university presidents try to answer our listeners’ questions. The result? Not much pomp and a whole lot of circumstance.',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-05-14T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/what-will-college-look-like-in-the-fall-and-beyond',
+					enclosure: {
+						length: '53607601',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/e4acbb27-0ffb-4579-bd34-abbb001adcc4/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 3349,
+					summary:
+						'Three university presidents try to answer our listeners’ questions. The result? Not much pomp and a whole lot of circumstance.',
+				},
+				{
+					title: '417. Reasons to Be Cheerful',
+					description:
+						'Humans have a built-in “negativity bias,” which means we give bad news much more power than good. Would the Covid-19 crisis be an opportune time to reverse this tendency?',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-05-07T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/reasons-to-be-cheerful',
+					enclosure: {
+						length: '47994357',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/b5e9faca-2046-43c5-a88a-abb301764aa0/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2998,
+					summary:
+						'Humans have a built-in “negativity bias,” which means we give bad news much more power than good. Would the Covid-19 crisis be an opportune time to reverse this tendency?',
+				},
+				{
+					title: '416. How Do You Reopen a Country?',
+					description:
+						'We speak with a governor, a former C.D.C. director, a pandemic forecaster, a hard-charging pharmacist, and a pair of economists — who say it’s all about the incentives. (Pandemillions, anyone?)',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-04-30T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/how-do-you-reopen-a-country',
+					enclosure: {
+						length: '51706265',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/82a1de9c-3c7d-4469-a27a-abad000f571a/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 3230,
+					summary:
+						'We speak with a governor, a former C.D.C. director, a pandemic forecaster, a hard-charging pharmacist, and a pair of economists — who say it’s all about the incentives. (Pandemillions, anyone?)',
+				},
+				{
+					title: '415. How Rahm Emanuel Would Run the World',
+					description:
+						'As a former top adviser to presidents Clinton and Obama, he believes in the power of the federal government. But as former mayor of Chicago, he says that cities are where real problems get solved — especially in the era of Covid-19.',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-04-27T00:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/how-rahm-emanuel-would-run-the-world',
+					enclosure: {
+						length: '45018516',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/8c926296-d567-4c64-9339-aba9014c0a33/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2812,
+					summary:
+						'As a former top adviser to presidents Clinton and Obama, he believes in the power of the federal government. But as former mayor of Chicago, he says that cities are where real problems get solved — especially in the era of Covid-19.',
+				},
+				{
+					title:
+						'414. Will Covid-19 Spark a Cold War (or Worse) With China?',
+					description:
+						'The U.S. spent the past few decades waiting for China to act like the global citizen it said it wanted to be. The waiting may be over.',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-04-23T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/will-covid-19-spark-a-cold-war-or-worse-with-china',
+					enclosure: {
+						length: '55434510',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/5eb85df4-0ff5-444d-83bd-aba6000ef51c/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 3463,
+					summary:
+						'The U.S. spent the past few decades waiting for China to act like the global citizen it said it wanted to be. The waiting may be over.',
+				},
+				{
+					title: '413. Who Gets the Ventilator?',
+					description:
+						'Should a nurse or doctor who gets sick treating Covid-19 patients have priority access to a potentially life-saving healthcare device? Americans aren’t used to rationing in medicine, but it’s time to think about it. We consult a lung specialist, a bioethicist, and (of course) an economist.',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-04-16T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/who-gets-the-ventilator',
+					enclosure: {
+						length: '46186270',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/4dc01382-3f38-4db9-8855-ab9e016247a9/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2885,
+					summary:
+						'Should a nurse or doctor who gets sick treating Covid-19 patients have priority access to a potentially life-saving healthcare device? Americans aren’t used to rationing in medicine, but it’s time to think about it. We consult a lung specialist, a bioethicist, and (of course) an economist.',
+				},
+				{
+					title: '412. What Happens When Everyone Stays Home to Eat?',
+					description:
+						'Covid-19 has shocked our food-supply system like nothing in modern history. We examine the winners, the losers, the unintended consequences — and just how much toilet paper one household really needs.',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-04-09T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/what-happens-when-everyone-stays-home-to-eat',
+					enclosure: {
+						length: '44170494',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/bc0a5578-4ec4-4869-bbc3-ab9800137b08/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2759,
+					summary:
+						'Covid-19 has shocked our food-supply system like nothing in modern history. We examine the winners, the losers, the unintended consequences — and just how much toilet paper one household really needs.',
+				},
+				{
+					title:
+						'411. Is $2 Trillion the Right Medicine for a Sick Economy?',
+					description:
+						'Congress just passed the biggest aid package in modern history. We ask six former White House economic advisors and one U.S. Senator: Will it actually work? What are its best and worst features? Where does $2 trillion come from, and what are the long-term effects of all that government spending? ',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-04-02T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/is-2-trillion-the-right-medicine-for-a-sick-econom',
+					enclosure: {
+						length: '51066419',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/7c880646-1724-4390-a903-ab90016d7d8d/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 3190,
+					summary:
+						'Congress just passed the biggest aid package in modern history. We ask six former White House economic advisors and one U.S. Senator: Will it actually work? What are its best and worst features? Where does $2 trillion come from, and what are the long-term effects of all that government spending? ',
+				},
+				{
+					title:
+						'410. What Does Covid-19 Mean for Cities (and Marriages)?',
+					description:
+						'There are a lot of upsides to urban density — but viral contagion is not one of them. Also: a nationwide lockdown will show if familiarity really breeds contempt. And: how to help your neighbor.',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-03-26T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/what-does-covid-19-mean-for-cities-and-marriages',
+					enclosure: {
+						length: '38443630',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/832c6e38-437d-439a-8c24-ab89016d99ac/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2401,
+					summary:
+						'There are a lot of upsides to urban density — but viral contagion is not one of them. Also: a nationwide lockdown will show if familiarity really breeds contempt. And: how to help your neighbor.',
+				},
+				{
+					title: '409. The Side Effects of Social Distancing',
+					description:
+						'In just a few weeks, the novel coronavirus has undone a century’s worth of our economic and social habits. What consequences will this have on our future — and is there a silver lining in this very black pandemic cloud?',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-03-19T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/the-side-effects-of-social-distancing',
+					enclosure: {
+						length: '46058400',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/b60ce786-1808-4f94-95c4-ab82017fc8fd/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2877,
+					summary:
+						'In just a few weeks, the novel coronavirus has undone a century’s worth of our economic and social habits. What consequences will this have on our future — and is there a silver lining in this very black pandemic cloud?',
+				},
+				{
+					title:
+						'Why Rent Control Doesn’t Work (Ep. 373 Rebroadcast)',
+					description:
+						'As cities become ever-more expensive, politicians and housing advocates keep calling for rent control. Economists think that’s a terrible idea. They say it helps a small (albeit noisy) group of renters, but keeps overall rents artificially high by disincentivizing new construction. So what happens next?',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-03-12T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/why-rent-control-doesn-t-work-rebroadcast',
+					enclosure: {
+						length: '45178624',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/5219b02c-2a07-4e40-97e4-ab7b0122e10e/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2822,
+					summary:
+						'As cities become ever-more expensive, politicians and housing advocates keep calling for rent control. Economists think that’s a terrible idea. They say it helps a small (albeit noisy) group of renters, but keeps overall rents artificially high by disincentivizing new construction. So what happens next?',
+				},
+				{
+					title: '408. Does Anyone Really Know What Socialism Is?',
+					description:
+						'Trump says it would destroy us. Sanders says it will save us. The majority of millennials would like it to replace capitalism. But what is “it”? We bring in the economists to sort things out and tell us what the U.S. can learn from the good (and bad) experiences of other (supposedly) socialist countries.',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-03-05T04:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/does-anyone-really-know-what-socialism-is',
+					enclosure: {
+						length: '41738384',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/25299a35-e94c-434a-9420-ab7401446c71/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2607,
+					summary:
+						'Trump says it would destroy us. Sanders says it will save us. The majority of millennials would like it to replace capitalism. But what is “it”? We bring in the economists to sort things out and tell us what the U.S. can learn from the good (and bad) experiences of other (supposedly) socialist countries.',
+				},
+				{
+					title: '407. Is There Really a “Loneliness Epidemic”?',
+					description:
+						'That’s what some health officials are saying, but the data aren’t so clear. We look into what’s known (and not known) about the prevalence and effects of loneliness — including the possible upsides.',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-02-27T04:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/is-there-really-a-loneliness-epidemic',
+					enclosure: {
+						length: '32122393',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/207e0117-0e91-42c0-8c76-ab6d018a7ac2/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2006,
+					summary:
+						'That’s what some health officials are saying, but the data aren’t so clear. We look into what’s known (and not known) about the prevalence and effects of loneliness — including the possible upsides.',
+				},
+				{
+					title: '406. Can You Hear Me Now?',
+					description:
+						'When he became chairman of the Federal Communications Commission, Ajit Pai announced that he was going to take a “weed whacker” to Obama-era regulations. So far, he’s kept his promise, and earned the internet’s ire for reversing the agency’s position on net neutrality. Pai defends his actions and explains how the U.S. can “win” everything from the 5G race to the war on robocalls.',
+					imageURL:
+						'https://www.omnycontent.com/d/playlist/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a/image.jpg?t=1589407970&size=Large',
+					pubDate: '2020-02-20T04:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/can-you-hear-me-now',
+					enclosure: {
+						length: '46138614',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/71ecb1bb-da6e-4c31-9c19-ab670000a6f3/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2882,
+					summary:
+						'When he became chairman of the Federal Communications Commission, Ajit Pai announced that he was going to take a “weed whacker” to Obama-era regulations. So far, he’s kept his promise, and earned the internet’s ire for reversing the agency’s position on net neutrality. Pai defends his actions and explains how the U.S. can “win” everything from the 5G race to the war on robocalls.',
+				},
+				{
+					title:
+						'401. How Many Prince Charleses Can There Be in One Room?',
+					description:
+						'In a special holiday episode, Stephen Dubner and Angela Duckworth take turns asking each other questions about charisma, wealth vs. intellect, and (of course) grit.',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/1ddb65b2-39f4-48d3-898c-ab2f005bc652/image.jpg?t=1577338451&size=Large',
+					pubDate: '2019-12-26T04:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/how-many-prince-charleses-can-there-be-in-one-room',
+					enclosure: {
+						length: '32506520',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/1ddb65b2-39f4-48d3-898c-ab2f005bc652/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2030,
+					summary:
+						'In a special holiday episode, Stephen Dubner and Angela Duckworth take turns asking each other questions about charisma, wealth vs. intellect, and (of course) grit.',
+				},
+				{
+					title: '389. How to Make Meetings Less Terrible',
+					description:
+						'In the U.S. alone, we hold 55 million meetings a day. Most of them are woefully unproductive, and tyrannize our offices. The revolution begins now — with better agendas, smaller invite lists, and an embrace of healthy conflict.',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/dadc591f-02b8-4ea8-8168-ab0d000b14a9/image.jpg?t=1574383222&size=Large',
+					pubDate: '2019-09-19T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/how-to-make-meetings-less-terrible',
+					enclosure: {
+						length: '40059844',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/dadc591f-02b8-4ea8-8168-ab0d000b14a9/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2502,
+					summary:
+						'In the U.S. alone, we hold 55 million meetings a day. Most of them are woefully unproductive, and tyrannize our offices. The revolution begins now — with better agendas, smaller invite lists, and an embrace of healthy conflict.',
+				},
+				{
+					title: '388. The Economics of Sports Gambling',
+					description:
+						'What happens when tens of millions of fantasy-sports players are suddenly able to bet real money on real games? We’re about to find out. A recent Supreme Court decision has cleared the way to bring an estimated $300 billion in black-market sports betting into the light. We sort out the winners and losers.',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/82c40ece-6738-4c9c-ae6b-ab0d000b2440/image.jpg?t=1574383237&size=Large',
+					pubDate: '2019-09-05T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/the-economics-of-sports-gambling',
+					enclosure: {
+						length: '52715644',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/82c40ece-6738-4c9c-ae6b-ab0d000b2440/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 3293,
+					summary:
+						'What happens when tens of millions of fantasy-sports players are suddenly able to bet real money on real games? We’re about to find out. A recent Supreme Court decision has cleared the way to bring an estimated $300 billion in black-market sports betting into the light. We sort out the winners and losers.',
+				},
+				{
+					title:
+						'386. How the Supermarket Helped America Win the Cold War',
+					description:
+						'Aisle upon aisle of fresh produce, cheap meat, and sugary cereal — a delicious embodiment of free-market capitalism, right? Not quite. The supermarket was in fact the endpoint of the U.S. government’s battle for agricultural abundance against the U.S.S.R. Our farm policies were built to dominate, not necessarily to nourish — and we are still living with the consequences.',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/e681e0f4-941b-4be5-a756-ab0d000b4eb8/image.jpg?t=1574383272&size=Large',
+					pubDate: '2019-08-01T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/how-the-supermarket-helped-america-win-the-cold-wa',
+					enclosure: {
+						length: '37947930',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/e681e0f4-941b-4be5-a756-ab0d000b4eb8/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2370,
+					summary:
+						'Aisle upon aisle of fresh produce, cheap meat, and sugary cereal — a delicious embodiment of free-market capitalism, right? Not quite. The supermarket was in fact the endpoint of the U.S. government’s battle for agricultural abundance against the U.S.S.R. Our farm policies were built to dominate, not necessarily to nourish — and we are still living with the consequences.',
+				},
+				{
+					title: '384. Abortion and Crime, Revisited',
+					description:
+						'The controversial theory linking Roe v. Wade to a massive crime drop is back in the spotlight as several states introduce abortion restrictions. Steve Levitt and John Donohue discuss their original research, the challenges to its legitimacy, and their updated analysis. Also: what this means for abortion policy, crime policy, and having intelligent conversations about contentious topics.',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/2bc7a738-3da1-4dd5-9fa3-ab0d000b6842/image.jpg?t=1574383294&size=Large',
+					pubDate: '2019-07-11T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/abortion-and-crime-revisited',
+					enclosure: {
+						length: '53131507',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/2bc7a738-3da1-4dd5-9fa3-ab0d000b6842/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 3319,
+					summary:
+						'The controversial theory linking Roe v. Wade to a massive crime drop is back in the spotlight as several states introduce abortion restrictions. Steve Levitt and John Donohue discuss their original research, the challenges to its legitimacy, and their updated analysis. Also: what this means for abortion policy, crime policy, and having intelligent conversations about contentious topics.',
+				},
+				{
+					title: '383. The Zero-Minute Workout',
+					description:
+						'There is strong evidence that exercise is wildly beneficial. There is even stronger evidence that most people hate to exercise. So if a pill could mimic the effects of working out, why wouldn’t we want to take it?',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/601d16b7-2a1a-4bb6-bddf-ab0d000b79db/image.jpg?t=1574383310&size=Large',
+					pubDate: '2019-06-27T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/the-zero-minute-workout',
+					enclosure: {
+						length: '35916175',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/601d16b7-2a1a-4bb6-bddf-ab0d000b79db/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2243,
+					summary:
+						'There is strong evidence that exercise is wildly beneficial. There is even stronger evidence that most people hate to exercise. So if a pill could mimic the effects of working out, why wouldn’t we want to take it?',
+				},
+				{
+					title: '379. How to Change Your Mind',
+					description:
+						'There are a lot of barriers to changing your mind: ego, overconfidence, inertia — and cost. Politicians who flip-flop get mocked; family and friends who cross tribal borders are shunned. But shouldn’t we be encouraging people to change their minds? And how can we get better at it ourselves?',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/cce1073d-0c94-4a50-9bc7-ab0d000b9b94/image.jpg?t=1574383338&size=Large',
+					pubDate: '2019-05-30T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/how-to-change-your-mind',
+					enclosure: {
+						length: '44043809',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/cce1073d-0c94-4a50-9bc7-ab0d000b9b94/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2751,
+					summary:
+						'There are a lot of barriers to changing your mind: ego, overconfidence, inertia — and cost. Politicians who flip-flop get mocked; family and friends who cross tribal borders are shunned. But shouldn’t we be encouraging people to change their minds? And how can we get better at it ourselves?',
+				},
+				{
+					title:
+						'374. How Spotify Saved the Music Industry (But Not Necessarily Musicians)',
+					description:
+						'Daniel Ek, a 23-year-old Swede who grew up on pirated music, made the record labels an offer they couldn’t refuse: a legal platform to stream all the world’s music. Spotify reversed the labels’ fortunes, made Ek rich, and thrilled millions of music fans. But what has it done for all those musicians stuck in the long tail?',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/b8c821a4-779a-4b69-91d4-ab0d000bece7/image.jpg?t=1574383408&size=Large',
+					pubDate: '2019-04-11T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/how-spotify-saved-the-music-industry-but-not-neces',
+					enclosure: {
+						length: '55307899',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/b8c821a4-779a-4b69-91d4-ab0d000bece7/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 3455,
+					summary:
+						'Daniel Ek, a 23-year-old Swede who grew up on pirated music, made the record labels an offer they couldn’t refuse: a legal platform to stream all the world’s music. Spotify reversed the labels’ fortunes, made Ek rich, and thrilled millions of music fans. But what has it done for all those musicians stuck in the long tail?',
+				},
+				{
+					title: '310. Are We Running Out of Ideas?',
+					description:
+						'Economists have a hard time explaining why productivity growth has been shrinking. One theory: true innovation has gotten much harder – and much more expensive. So what should we do next?',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/c8cd61f0-62e3-4bb5-91d5-ab0d000f98fe/image.jpg?t=1574384214&size=Large',
+					pubDate: '2017-11-30T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/are-we-running-out-of-ideas',
+					enclosure: {
+						length: '35555486',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/c8cd61f0-62e3-4bb5-91d5-ab0d000f98fe/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2221,
+					summary:
+						'Economists have a hard time explaining why productivity growth has been shrinking. One theory: true innovation has gotten much harder – and much more expensive. So what should we do next?',
+				},
+				{
+					title: '305. The Demonization of Gluten',
+					description:
+						"Celiac disease is thought to affect roughly one percent of the population. The good news: it can be treated by quitting gluten. The bad news: many celiac patients haven't been diagnosed. The weird news: millions of people without celiac disease have quit gluten – which may be a big mistake.",
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/85244356-75a1-45a0-ba75-ab0d000fdd00/image.jpg?t=1574384268&size=Large',
+					pubDate: '2017-10-19T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/the-demonization-of-gluten',
+					enclosure: {
+						length: '42246590',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/85244356-75a1-45a0-ba75-ab0d000fdd00/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2639,
+					summary:
+						"Celiac disease is thought to affect roughly one percent of the population. The good news: it can be treated by quitting gluten. The bad news: many celiac patients haven't been diagnosed. The weird news: millions of people without celiac disease have quit gluten – which may be a big mistake.",
+				},
+				{
+					title: '299. "How Much Brain Damage Do I Have?"',
+					description:
+						"John Urschel was the only player in the N.F.L. simultaneously getting a math Ph.D. at M.I.T. But after a new study came out linking football to brain damage, he abruptly retired. Here's the inside story — and a look at how we make decisions in the face of risk versus uncertainty.",
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/9b9ac362-66a7-4ebd-9356-ab0d00101901/image.jpg?t=1574384320&size=Large',
+					pubDate: '2017-09-07T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/how-much-brain-damage-do-i-have',
+					enclosure: {
+						length: '45275975',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/9b9ac362-66a7-4ebd-9356-ab0d00101901/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2828,
+					summary:
+						"John Urschel was the only player in the N.F.L. simultaneously getting a math Ph.D. at M.I.T. But after a new study came out linking football to brain damage, he abruptly retired. Here's the inside story — and a look at how we make decisions in the face of risk versus uncertainty.",
+				},
+				{
+					title:
+						'298. Everything You Always Wanted to Know About Money (But Were Afraid to Ask)',
+					description:
+						"The bad news: roughly 70 percent of Americans are financially illiterate. The good news: all the important stuff can fit on one index card. Here's how to become your own financial superhero.",
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/bdc9abe1-3997-4996-894e-ab0d00107a46/image.jpg?t=1574384402&size=Large',
+					pubDate: '2017-08-03T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/everything-you-always-wanted-to-know-about-money-1',
+					enclosure: {
+						length: '42345323',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/bdc9abe1-3997-4996-894e-ab0d00107a46/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2645,
+					summary:
+						"The bad news: roughly 70 percent of Americans are financially illiterate. The good news: all the important stuff can fit on one index card. Here's how to become your own financial superhero.",
+				},
+				{
+					title:
+						'297. The Stupidest Thing You Can Do With Your Money',
+					description:
+						"It's hard enough to save for a house, tuition, or retirement. So why are we willing to pay big fees for subpar investment returns? Enter the low-cost index fund. The revolution will not be monetized.",
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/106d08e0-df98-4078-b834-ab0d001083ca/image.jpg?t=1574384410&size=Large',
+					pubDate: '2017-07-27T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/the-stupidest-thing-you-can-do-with-your-money',
+					enclosure: {
+						length: '46174611',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/106d08e0-df98-4078-b834-ab0d001083ca/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2884,
+					summary:
+						"It's hard enough to save for a house, tuition, or retirement. So why are we willing to pay big fees for subpar investment returns? Enter the low-cost index fund. The revolution will not be monetized.",
+				},
+				{
+					title:
+						'288. Are the Rich Really Less Generous Than the Poor?',
+					description:
+						"A series of academic studies suggest that the wealthy are, to put it bluntly, selfish jerks. It's an easy narrative to swallow — but is it true? A trio of economists set out to test the theory. All it took was a Dutch postal worker's uniform, some envelopes stuffed with cash, and a slight sense of the absurd.",
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/4922c5e6-171b-4097-91ba-ab0d0010df8b/image.jpg?t=1574384488&size=Large',
+					pubDate: '2017-05-25T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/are-the-rich-really-less-generous-than-the-poor',
+					enclosure: {
+						length: '40732786',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/4922c5e6-171b-4097-91ba-ab0d0010df8b/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2544,
+					summary:
+						"A series of academic studies suggest that the wealthy are, to put it bluntly, selfish jerks. It's an easy narrative to swallow — but is it true? A trio of economists set out to test the theory. All it took was a Dutch postal worker's uniform, some envelopes stuffed with cash, and a slight sense of the absurd.",
+				},
+				{
+					title: '285. There’s a War on Sugar. Is It Justified?',
+					description:
+						"Some people argue that sugar should be regulated, like alcohol and tobacco, on the grounds that it's addictive and toxic. How much sense does that make? We hear from a regulatory advocate, an evidence-based skeptic, a former FDA commissioner — and the organizers of Milktoberfest.",
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/b4260e33-eca5-4478-afd9-ab0d0010ff49/image.jpg?t=1574384517&size=Large',
+					pubDate: '2017-04-27T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/there-s-a-war-on-sugar-is-it-justified',
+					enclosure: {
+						length: '43869554',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/b4260e33-eca5-4478-afd9-ab0d0010ff49/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2740,
+					summary:
+						"Some people argue that sugar should be regulated, like alcohol and tobacco, on the grounds that it's addictive and toxic. How much sense does that make? We hear from a regulatory advocate, an evidence-based skeptic, a former FDA commissioner — and the organizers of Milktoberfest.",
+				},
+				{
+					title: '279. Why Is My Life So Hard?',
+					description:
+						'Most of us feel we face more headwinds and obstacles than everyone else — which breeds resentment. We also undervalue the tailwinds that help us — which leaves us ungrateful and unhappy. How can we avoid this trap?',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/4dc71042-4d6a-4ad9-8773-ab0d00113b59/image.jpg?t=1574384566&size=Large',
+					pubDate: '2017-03-16T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/why-is-my-life-so-hard',
+					enclosure: {
+						length: '29342513',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/4dc71042-4d6a-4ad9-8773-ab0d00113b59/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 1832,
+					summary:
+						'Most of us feel we face more headwinds and obstacles than everyone else — which breeds resentment. We also undervalue the tailwinds that help us — which leaves us ungrateful and unhappy. How can we avoid this trap?',
+				},
+				{
+					title: '255. Ten Ideas to Make Politics Less Rotten',
+					description:
+						'We Americans may love our democracy -- at least in theory -- but at the moment our feelings toward the federal government lie somewhere between disdain and hatred. Which electoral and political ideas should be killed off to make way for a saner system?',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/097b9a09-2718-4ae4-86e0-ab0d00126347/image.jpg?t=1574384819&size=Large',
+					pubDate: '2016-07-28T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/ten-ideas-to-make-politics-less-rotten',
+					enclosure: {
+						length: '41360541',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/097b9a09-2718-4ae4-86e0-ab0d00126347/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2583,
+					summary:
+						'We Americans may love our democracy -- at least in theory -- but at the moment our feelings toward the federal government lie somewhere between disdain and hatred. Which electoral and political ideas should be killed off to make way for a saner system?',
+				},
+				{
+					title: '246. How to Get More Grit in Your Life',
+					description:
+						"The psychologist Angela Duckworth argues that a person's level of stick-to-itiveness is directly related to their level of success. No big surprise there. But grit, she says, isn't something you're born with -- it can be learned. Here's how.",
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/8085eb3c-569e-47a2-8e33-ab0d0012fcd4/image.jpg?t=1574384951&size=Large',
+					pubDate: '2016-05-05T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/how-to-get-more-grit-in-your-life-1',
+					enclosure: {
+						length: '42729453',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/8085eb3c-569e-47a2-8e33-ab0d0012fcd4/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2669,
+					summary:
+						"The psychologist Angela Duckworth argues that a person's level of stick-to-itiveness is directly related to their level of success. No big surprise there. But grit, she says, isn't something you're born with -- it can be learned. Here's how.",
+				},
+				{
+					title: '244. How to Become Great at Just About Anything',
+					description:
+						'What if the thing we call "talent" is grotesquely overrated? And what if deliberate practice is the secret to excellence? Those are the claims of the research psychologist Anders Ericsson, who has been studying the science of expertise for decades. He tells us everything he\'s learned.',
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/1025cd68-fc77-477d-a4ae-ab0d00130d38/image.jpg?t=1574384965&size=Large',
+					pubDate: '2016-04-28T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/how-to-become-great-at-just-about-anything',
+					enclosure: {
+						length: '46171259',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/1025cd68-fc77-477d-a4ae-ab0d00130d38/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2884,
+					summary:
+						'What if the thing we call "talent" is grotesquely overrated? And what if deliberate practice is the secret to excellence? Those are the claims of the research psychologist Anders Ericsson, who has been studying the science of expertise for decades. He tells us everything he\'s learned.',
+				},
+				{
+					title: '243. How to Be More Productive',
+					description:
+						"It's Self-Improvement Month at Freakonomics Radio. We begin with a topic that seems to be on everyone's mind: how to get more done in less time. First, however, a warning: there's a big difference between being busy and being productive.",
+					imageURL:
+						'https://www.omnycontent.com/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d40dd16d-8119-49ac-aed4-ab0d001313cd/image.jpg?t=1574384969&size=Large',
+					pubDate: '2016-04-21T03:00:00.000Z',
+					link:
+						'https://omny.fm/shows/freakonomics-radio/how-to-be-more-productive',
+					enclosure: {
+						length: '37106944',
+						type: 'audio/mpeg',
+						url:
+							'https://chtbl.com/track/288D49/traffic.omny.fm/d/clips/aaea4e69-af51-495e-afc9-a9760146922b/14a43378-edb2-49be-8511-ab0d000a7030/d40dd16d-8119-49ac-aed4-ab0d001313cd/audio.mp3?utm_source=Podcast&in_playlist=d1b9612f-bb1b-4b85-9c0c-ab0d004ab37a',
+					},
+					duration: 2318,
+					summary:
+						"It's Self-Improvement Month at Freakonomics Radio. We begin with a topic that seems to be on everyone's mind: how to get more done in less time. First, however, a warning: there's a big difference between being busy and being productive.",
+				},
+			],
+		},
+		isPlaying: true,
+		seekSliderValueChange: { seekSliderValueChange: () => {} },
+		seekSliderSlidingComplete: { seekSliderSlidingComplete: () => {} },
+		playOrPause: { playOrPause: () => {} },
+		skipSeconds: { skipSeconds: () => {} },
+	}
+
+	return <PlayerScreen {...props} />
+}

--- a/storybook/stories/Podcasts.js
+++ b/storybook/stories/Podcasts.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import top100 from '@app/modules/podcasts/top100'
+import Podcasts from '../../src/components/screens/Podcasts/PodcastsScreen'
+
+export default function () {
+	const props = {
+		subscriptions: top100,
+		selectPodcast: { selectPodcast: () => {} },
+	}
+
+	return <Podcasts {...props} />
+}

--- a/storybook/stories/index.js
+++ b/storybook/stories/index.js
@@ -15,6 +15,7 @@ import Profile from './Profile'
 import Settings from './Settings'
 import TopCharts from './TopCharts'
 import Podcasts from './Podcasts'
+import Player from './Player'
 
 const store = createStore(rootReducer)
 
@@ -33,3 +34,4 @@ storiesOf('UI Components', module)
 	.add('Settings', () => <Settings />)
 	.add('TopCharts', () => <TopCharts />)
 	.add('Podcasts', () => <Podcasts />)
+	.add('Player', () => <Player />)

--- a/storybook/stories/index.js
+++ b/storybook/stories/index.js
@@ -14,6 +14,7 @@ import Explore from './Explore'
 import Profile from './Profile'
 import Settings from './Settings'
 import TopCharts from './TopCharts'
+import Podcasts from './Podcasts'
 
 const store = createStore(rootReducer)
 
@@ -31,3 +32,4 @@ storiesOf('UI Components', module)
 	.add('Profile', () => <Profile />)
 	.add('Settings', () => <Settings />)
 	.add('TopCharts', () => <TopCharts />)
+	.add('Podcasts', () => <Podcasts />)


### PR DESCRIPTION
- split player and podcasts to container and presentational components

- added them to storybook

- fixed navigation due to the updates above

Relates #41 

